### PR TITLE
Fixed FilenameUtils

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/cargo/util/FilenameUtils.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/util/FilenameUtils.groovy
@@ -24,8 +24,9 @@ final class FilenameUtils {
     private FilenameUtils() {}
 
     static String getExtension(String fileName) {
-        if (fileName.contains('.')) {
-            return fileName.substring(fileName.lastIndexOf('.'))
+		int index = fileName.lastIndexOf('.')
+        if (index > 0) {
+            return fileName.substring(index + 1)
         }
 
         ''


### PR DESCRIPTION
FilenameUtils.getExtension(String fileName) had an off by 1 error.
Instead of 'war' it returned '.war'

-Leonard
