### PR TITLE
ZIP installer for JBoss

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/cargo/CargoPlugin.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/CargoPlugin.groovy
@@ -100,6 +100,9 @@ class CargoPlugin implements Plugin<Project> {
             localContainerTask.conventionMapping.map('logFile') {
                 CargoProjectProperty.getTypedProperty(project, LocalContainerTaskProperty.LOG, cargoConvention.local.log)
             }
+			localContainerTask.conventionMapping.map('zipUrlInstaller') {
+				cargoConvention.local.zipUrlInstaller
+			}
         }
     }
 


### PR DESCRIPTION
I tried to use the installer closure for a 'jboss71x' container but it seems like it only works for the available specific local containers (tomcat, jetty et cetera). Could you please review my change to enable it for the (default) LocalContainerConventionMapping. Maybe this could be refactored to a JBoss specific configuration method if should not be applicable for all containers.

Thx in advance,

Regards,

Moritz
