### PR TITLE
Letting the "Press Ctrl-C to stop the container..." message through

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/cargo/LocalContainerTask.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/LocalContainerTask.groovy
@@ -56,7 +56,7 @@ class LocalContainerTask extends AbstractContainerTask {
     }
 
     @Override
-    void runAction() {
+    void subclassRunAction() {
         log.info "Starting action '${getAction()}' for local container '${Container.getContainerForId(getContainerId()).description}'"
 
         ant.taskdef(resource: CARGO_TASKS, classpath: getClasspath().asPath)

--- a/src/main/groovy/org/gradle/api/plugins/cargo/RemoteContainerTask.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/RemoteContainerTask.groovy
@@ -30,7 +30,7 @@ class RemoteContainerTask extends AbstractContainerTask {
     String password
 
     @Override
-    void runAction() {
+    void subclassRunAction() {
         log.info "Starting action '${getAction()}' for remote container '${Container.getContainerForId(getContainerId()).description}' on '${getProtocol()}://${getHostname()}:${getPort()}'"
 
         ant.taskdef(resource: CARGO_TASKS, classpath: getClasspath().asPath)


### PR DESCRIPTION
Hi,

We've been using your plugin at work (thanks!) and it's been really helpful.  One thing we've been missing is the "Press Ctrl-C to stop the container..." message that comes up in the maven and ant tasks when you run locally.  This pull request adds a listener at the start of the task that listens for info level ant task messages from the cargo tasks and logs them at the lifecycle priority level in gradle.  It then is removed at the end of task, since the ant Project used is the same between tasks.  It also only logs messages from the task thread, so that is parallel build safe.  I tested it on tomcat local and jetty local and remote.  Thanks again!
- David
