### PR TITLE
Adding support of the cargo timeout property

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ The Cargo plugin defines the following convention properties in the `cargo` clos
 
 * `containerId`: The container ID you are targeting. Please see the [list of supported containers](http://cargo.codehaus.org/Home) on the Cargo website.
 * `port`: The TCP port the container responds on (defaults to 8080).
-* `timeout`: The timeout (in ms) in which to determine if the container is successfully started or stopped (cargo sets this default to 120000ms).
 
 Within `cargo` you can define optional properties for the 1..n deployment artifacts in a closure named `deployable`. Each
 deployment artifact would be specified in its own closure:
@@ -88,6 +87,7 @@ Within `cargo` you can define properties for local containers in a closure named
 container's configuration. The `configFile` is a closure itself and requires you to provide the attributes `file` and `todir`.
 Multiple configuration file be defined by creating more than one `configFile` closure.
 * `rmiPort`: The port to use when communicating with this server, for example to start and stop it.
+* `timeout`: The timeout (in ms) in which to determine if the container is successfully started or stopped (cargo sets this default to 120000ms).
 
 Within `local` you can define properties for specific local containers. At the moment the following containers are supported
 defined by these closures:
@@ -143,6 +143,7 @@ by project properties. The name of the project properties is the same as in the 
         local {
             homeDir = file('/home/user/dev/tools/apache-tomcat-6.0.32')
             output = file('build/output.log')
+            timeout = 60000
 
             tomcat {
                 ajpPort = 9091

--- a/src/main/groovy/org/gradle/api/plugins/cargo/AbstractContainerTask.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/AbstractContainerTask.groovy
@@ -37,7 +37,6 @@ abstract class AbstractContainerTask extends DefaultTask {
     String containerId
     String action
     Integer port
-    Integer timeout
     String context
     @InputFiles FileCollection classpath
     @Input List<Deployable> deployables

--- a/src/main/groovy/org/gradle/api/plugins/cargo/LocalContainerTask.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/LocalContainerTask.groovy
@@ -36,6 +36,7 @@ class LocalContainerTask extends AbstractContainerTask {
     File logFile
     @Input @Optional Integer rmiPort
     ZipUrlInstaller zipUrlInstaller
+    @Input @Optional Integer timeout
     List<ConfigFile> configFiles
     List<BinFile> files
 

--- a/src/main/groovy/org/gradle/api/plugins/cargo/property/AbstractContainerTaskProperty.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/property/AbstractContainerTaskProperty.groovy
@@ -25,7 +25,7 @@ import groovy.util.logging.Slf4j
 @Slf4j
 enum AbstractContainerTaskProperty implements TaskProperty {
     CONTAINER_ID('cargo.container.id', PropertyDataType.STRING), PORT('cargo.port', PropertyDataType.INTEGER),
-    CONTEXT('cargo.context', PropertyDataType.STRING), TIMEOUT('cargo.timeout', PropertyDataType.INTEGER)
+    CONTEXT('cargo.context', PropertyDataType.STRING)
 
     static final Map PROPERTIES
 

--- a/src/main/groovy/org/gradle/api/plugins/cargo/property/LocalContainerTaskProperty.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/property/LocalContainerTaskProperty.groovy
@@ -27,7 +27,7 @@ enum LocalContainerTaskProperty implements TaskProperty {
     JVM_ARGS('cargo.jvmargs', PropertyDataType.STRING), LOG_LEVEL('cargo.log.level', PropertyDataType.STRING),
     HOME_DIR('cargo.home.dir', PropertyDataType.FILE), OUTPUT('cargo.output', PropertyDataType.FILE),
     LOG('cargo.log', PropertyDataType.FILE), RMI_PORT('cargo.rmi.port', PropertyDataType.INTEGER),
-    CONFIG_HOME_DIR('cargo.config.home.dir', PropertyDataType.FILE)
+    CONFIG_HOME_DIR('cargo.config.home.dir', PropertyDataType.FILE), TIMEOUT('cargo.timeout', PropertyDataType.INTEGER)
 
     static final Map PROPERTIES
 


### PR DESCRIPTION
I had a slow starting application and needed the ability to configure cargo's 'timeout' parameter. The Cargo Ant task uses the default fallback value of 120 seconds when the property is set to '0', so I used that value for the default convention property as well.
