### PR TITLE
configHomeDir input type

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/cargo/tasks/local/LocalCargoContainerTask.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/tasks/local/LocalCargoContainerTask.groovy
@@ -56,7 +56,7 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
     /**
      * The Cargo configuration home directory.
      */
-    @InputFile
+    @InputDirectory
     @Optional
     File configHomeDir
 


### PR DESCRIPTION
The input type for configHomeDir was set to `@InputFile` instead of `@InputDirectory`, which caused 

```
A problem was found with the configuration of task ':foo_web:cargoRunLocal'.
> File '/Project/path/foo/foo_web/build/cargo' specified for property 'configHomeDir' is not a file.
```
