### PR TITLE
Fixed the unit test title for correct output description.

### DIFF
--- a/src/test/groovy/org/gradle/api/plugins/cargo/util/CargoAntLoggingListenerSpec.groovy
+++ b/src/test/groovy/org/gradle/api/plugins/cargo/util/CargoAntLoggingListenerSpec.groovy
@@ -49,7 +49,7 @@ class CargoAntLoggingListenerSpec extends Specification {
             0 * mockLogger.lifecycle('Cargo started')
     }
 
-    void "Message logged for Cargo Ant task with debug priority"() {
+    void "Message not logged for Cargo Ant task with debug priority"() {
         given:
             Task antCargoTask = new CargoTask()
             BuildEvent buildEvent = new BuildEvent(antCargoTask)


### PR DESCRIPTION
A really pedantic change, sorry :-) I spotted this whilst looking at your project and how I can reuse your work around the ant logging listener.
