### PR TITLE
Support for JBoss74x (aka EAP 6.3.x) container

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/cargo/Container.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/cargo/Container.groovy
@@ -26,7 +26,7 @@ import groovy.util.logging.Slf4j
 enum Container {
     GERONIMO_1X('geronimo1x', 'Geronimo 1.x'), GERONIMO_2X('geronimo2x', 'Geronimo 2.x'), GERONIMO_3X('geronimo3x', 'Geronimo 3.x'),
     GLASSFISH_2X('glassfish2x', 'Glassfish 2.x'), GLASSFISH_3X('glassfish3x', 'Glassfish 3.x'), GLASSFISH_4X('glassfish4x', 'Glassfish 4.x'),
-    JBOSS_3X('jboss3x', 'JBoss 3.x'), JBOSS_4X('jboss4x', 'JBoss 4.x'), JBOSS_4_2X('jboss42x', 'JBoss 4.2.x'), JBOSS_5X('jboss5x', 'JBoss 5.x'), JBOSS_5_1X('jboss51x', 'JBoss 5.1.x'), JBOSS_6X('jboss6x', 'JBoss 6.x'), JBOSS_6_1X('jboss61x', 'JBoss 6.1.x'), JBOSS_7X('jboss7x', 'JBoss 7.x'), JBOSS_7_1X('jboss71x', 'JBoss 7.1.x'), JBOSS_7_2X('jboss72x', 'JBoss 7.2.x'), JBOSS_7_3X('jboss73x', 'JBoss 7.3.x'),
+    JBOSS_3X('jboss3x', 'JBoss 3.x'), JBOSS_4X('jboss4x', 'JBoss 4.x'), JBOSS_4_2X('jboss42x', 'JBoss 4.2.x'), JBOSS_5X('jboss5x', 'JBoss 5.x'), JBOSS_5_1X('jboss51x', 'JBoss 5.1.x'), JBOSS_6X('jboss6x', 'JBoss 6.x'), JBOSS_6_1X('jboss61x', 'JBoss 6.1.x'), JBOSS_7X('jboss7x', 'JBoss 7.x'), JBOSS_7_1X('jboss71x', 'JBoss 7.1.x'), JBOSS_7_2X('jboss72x', 'JBoss 7.2.x'), JBOSS_7_3X('jboss73x', 'JBoss 7.3.x'), JBOSS_7_4X('jboss74x', 'JBoss 7.4.x'),
     JETTY_4X('jetty4x', 'Jetty 4.x'), JETTY_5X('jetty5x', 'Jetty 5.x'), JETTY_6X('jetty6x', 'Jetty 6.x'), JETTY_7X('jetty7x', 'Jetty 7.x'), JETTY_8X('jetty8x', 'Jetty 8.x'), JETTY_9X('jetty9x', 'Jetty 9.x'),
     JO_1X('jo1x', 'jo! 1.x'),
     JONAS_4x('jonas4x', 'JOnAS 4.x'), JONAS_5x('jonas5x', 'JOnAS 5.x'),


### PR DESCRIPTION
I am not sure if the change in this single file is enough or not. Please let me know if there are some additional changes needed.

I am wondering, shouldn't the list of supported containers come directly from the particular cargo version? I have no idea if that is technically possible, but it would seem logical to let the underlying cargo version decide what containers it supports.
