### PR TITLE
Add Exploded War deployment support for local deployment mode

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/cargo/DeployableType.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/DeployableType.groovy
@@ -24,7 +24,7 @@ import groovy.util.logging.Slf4j
  */
 @Slf4j
 enum DeployableType {
-    WAR('war'), EAR('ear')
+    WAR('war'), EAR('ear'), EXPLODED('')
 
     static final Map DEPLOYABLE_TYPES
 

--- a/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
@@ -16,6 +16,7 @@
 package com.bmuschko.gradle.cargo.tasks.local
 
 import com.bmuschko.gradle.cargo.Container
+import com.bmuschko.gradle.cargo.DeployableType
 import com.bmuschko.gradle.cargo.convention.BinFile
 import com.bmuschko.gradle.cargo.convention.ConfigFile
 import com.bmuschko.gradle.cargo.convention.ZipUrlInstaller
@@ -188,13 +189,19 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
                 setContainerSpecificProperties()
 
                 getDeployables().each { deployable ->
+                    def deployableType = getDeployableType(deployable)
+
+                    if (DeployableType.EXPLODED == deployableType) {
+                        deployableType = DeployableType.WAR
+                    }
+
                     if(deployable.context) {
-                        ant.deployable(type: getDeployableType(deployable).filenameExtension, file: deployable.file) {
+                        ant.deployable(type: deployableType.filenameExtension, file: deployable.file) {
                             ant.property(name: AbstractCargoContainerTask.CARGO_CONTEXT, value: deployable.context)
                         }
                     }
                     else {
-                        ant.deployable(type: getDeployableType(deployable).filenameExtension, file: deployable.file)
+                        ant.deployable(type: deployableType.filenameExtension, file: deployable.file)
                     }
                 }
 

--- a/src/main/groovy/com/bmuschko/gradle/cargo/tasks/remote/RemoteCargoContainerTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/tasks/remote/RemoteCargoContainerTask.groovy
@@ -16,6 +16,7 @@
 package com.bmuschko.gradle.cargo.tasks.remote
 
 import com.bmuschko.gradle.cargo.Container
+import com.bmuschko.gradle.cargo.DeployableType
 import com.bmuschko.gradle.cargo.tasks.AbstractCargoContainerTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
@@ -62,6 +63,10 @@ class RemoteCargoContainerTask extends AbstractCargoContainerTask {
                     throw new InvalidUserDataException("Deployable "
                             + (deployable.file == null ? "null" : deployable.file.canonicalPath)
                             + " does not exist")
+                }
+
+                if(DeployableType.EXPLODED == getDeployableType(deployable)) {
+                    throw new InvalidUserDataException("Deployable type: EXPLODED is invalid for remote deployment")
                 }
 
                 logger.info "Deployable artifacts = ${getDeployables().collect { it.file.canonicalPath }}"


### PR DESCRIPTION
Add support for exploded war on local cargo mode. The change is totally transparent to end user as they just need to point to a directory in file property.