### PR TITLE
Changes ConfigFile and BinFile toDir from File to String

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,17 +355,17 @@ to use the file from at runtime. If you need more than one just create multiple 
         local {
             configFile {
                 file = file('src/main/jboss5/login-config.xml')
-                toDir = file('conf')
+                toDir = 'conf'
             }
 
             configFile {
                 file = file('src/main/jboss5/sample-roles.properties')
-                toDir = file('conf/props')
+                toDir = 'conf/props'
             }
 
             configFile {
                 file = file('src/main/jboss5/sample-users.properties')
-                toDir = file('conf/props')
+                toDir = 'conf/props'
             }
         }
     }
@@ -378,7 +378,7 @@ To add binary file(s) you should use `file` closure(s) instead:
         local {
             file {
                 file = file('../config/db/mysql-connector-java-5.1.23-bin.jar')
-                toDir = file('lib')
+                toDir = 'lib'
             }
         }
     }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### Version 2.0.4
+
+* Fixed configFile and file destination dir specification - [Pull request 121](https://github.com/bmuschko/gradle-cargo-plugin/pull/121).
+
 ### Version 2.0.3 (December 7, 2014)
 
 * Set Java target compatibility back to 1.6 - [Pull request 113](https://github.com/bmuschko/gradle-cargo-plugin/pull/113).

--- a/src/main/groovy/com/bmuschko/gradle/cargo/convention/BinFile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/convention/BinFile.groovy
@@ -21,8 +21,17 @@ package com.bmuschko.gradle.cargo.convention
  * @author Sascha Kiedrowski
  */
 class BinFile implements Serializable {
+
+    /**
+     * This specifies the path to the file that should be used.
+     * Can also specify a directory path if a whole directory needs to be copied over.
+     */
     File file
-    File toDir
+
+    /**
+     * This specified the name the directory that the file should be copied to relative to the configurations home.
+     */
+    String toDir
 
     @Override
     boolean equals(o) {

--- a/src/main/groovy/com/bmuschko/gradle/cargo/convention/ConfigFile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/convention/ConfigFile.groovy
@@ -21,8 +21,17 @@ package com.bmuschko.gradle.cargo.convention
  * @author Benjamin Muschko
  */
 class ConfigFile implements Serializable {
+
+    /**
+     * This specifies the path to the file that should be used.
+     * Can also specify a directory path if a whole directory needs to be copied over.
+     */
     File file
-    File toDir
+
+    /**
+     * This specified the name the directory that the file should be copied to relative to the configurations home.
+     */
+    String toDir
 
     @Override
     boolean equals(o) {

--- a/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
@@ -149,7 +149,7 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
                 }
             }
 
-            logger.info "Config files = ${getConfigFiles().collect { it.file.canonicalPath + " -> " + it.toDir.canonicalPath }}"
+            logger.info "Config files = ${getConfigFiles().collect { it.file.canonicalPath + " -> " + it.toDir }}"
         }
 
         if (!getFiles().isEmpty()) {
@@ -160,7 +160,7 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
                     + " does not exist")
                 }
             }
-            logger.info "Binary files = ${getFiles().collect { it.file.canonicalPath + " -> " + it.toDir.canonicalPath }}"
+            logger.info "Binary files = ${getFiles().collect { it.file.canonicalPath + " -> " + it.toDir }}"
         }
     }
 


### PR DESCRIPTION
When using cargo installer to boostrap a Wildfly 8.2 installation it is currently not possible to copy binary and config files.

Example configuration:

```
/*
 * Configure Cargo
 */
cargo {
	containerId = 'wildfly8x'
	port = 8080

	local {
		timeout = 120000
		installer {
			installUrl = 'http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.tar.gz'
			downloadDir = file("$buildDir/cargo/download/")
			extractDir = file("$buildDir/cargo/")
		}

        file {
            file = file('src/main/wildfly/configuration/binary/')
            toDir = file("configuration/")
        }

        // Configure property files
		configFile {
            file = file('src/main/wildfly/configuration/text/')
            toDir = file("configuration/")
        }
	}
}
```

Error:
```
Caused by: : org.codehaus.cargo.util.CargoException: Target directory [C:\Users\nwoehler\AppData\Local\Temp\cargo\conf/C:\Users\nwoehler\workspace\rapidminer-nexus\rapidminer-nexus-tests\configuration] cannot be created
        at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:116)
        at org.gradle.api.internal.project.ant.BasicAntBuilder.nodeCompleted(BasicAntBuilder.java:77)
        at org.gradle.api.internal.project.ant.BasicAntBuilder.doInvokeMethod(BasicAntBuilder.java:92)
```

* Reason:  The toDir has to be specified as a file which leads to erroneous parameters
* Solution: Make toDir a String parameter which allows to specify the relative configuration file folder. Afterwards the configuration above works just fine.

Correct configuration afterwards:

```
        file {
            file = file('src/main/wildfly/configuration/binary/')
            toDir = 'configuration/'
        }

        // Configure property files
		configFile {
            file = file('src/main/wildfly/configuration/text/')
            toDir = 'configuration/'
        }
```