### PR TITLE
Enable configuration for a local embedded container.

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/cargo/CargoPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/CargoPlugin.groovy
@@ -60,6 +60,7 @@ class CargoPlugin implements Plugin<Project> {
             conventionMapping.map('jvmArgs') { cargoPluginExtension.local.jvmArgs }
             conventionMapping.map('logLevel') { cargoPluginExtension.local.logLevel }
             conventionMapping.map('homeDir') { cargoPluginExtension.local.homeDir }
+            conventionMapping.map('configType') { cargoPluginExtension.local.configType }
             conventionMapping.map('configHomeDir') { cargoPluginExtension.local.configHomeDir }
             conventionMapping.map('outputFile') { cargoPluginExtension.local.outputFile }
             conventionMapping.map('logFile') { cargoPluginExtension.local.logFile }

--- a/src/main/groovy/com/bmuschko/gradle/cargo/convention/CargoLocalTaskConvention.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/convention/CargoLocalTaskConvention.groovy
@@ -26,6 +26,7 @@ class CargoLocalTaskConvention {
     String jvmArgs
     String logLevel
     File homeDir
+    String configType
     File configHomeDir
     File outputFile
     File logFile

--- a/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
@@ -59,6 +59,7 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
     /**
      * The Cargo configuration type.
      */
+    @Input
     @Optional
     String configType
 

--- a/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/LocalCargoContainerTask.groovy
@@ -57,6 +57,12 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
     File configHomeDir
 
     /**
+     * The Cargo configuration type.
+     */
+    @Optional
+    String configType
+
+    /**
      * The path to a file where container logs are saved.
      */
     @OutputFile
@@ -160,6 +166,12 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
             }
             logger.info "Binary files = ${getFiles().collect { it.file.canonicalPath + " -> " + it.toDir }}"
         }
+
+        if (getConfigType()) {
+            if (!['standalone','existing'].contains(getConfigType())) {
+                throw new InvalidUserDataException("Configuration type " + getConfigType() + " is not supported, use 'standalone' or 'existing'")
+            }
+        }
     }
 
     @Override
@@ -237,6 +249,10 @@ class LocalCargoContainerTask extends AbstractCargoContainerTask {
             }
 
             config['home'] = getConfigHomeDir().absolutePath
+        }
+
+        if(getConfigType()) {
+            config['type'] = getConfigType()
         }
 
         return config


### PR DESCRIPTION
Setting the configuration type to 'embedded' allows a preconfigured container configuration to be used
instead of cargo's auto-generated one.