### PR TITLE
Added CargoConfigureLocal task

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ The `cargo` plugin pre-defines the following tasks out-of-the-box:
         <td><a href="http://bmuschko.github.io/gradle-cargo-plugin/docs/groovydoc/com/bmuschko/gradle/cargo/tasks/local/CargoStopLocal.html">CargoStopLocal</a></td>
         <td>Stops local container.</td>
     </tr>
+    <tr>
+        <td>cargoConfigureLocal</td>
+        <td>-</td>
+        <td><a href="http://bmuschko.github.io/gradle-cargo-plugin/docs/groovydoc/com/bmuschko/gradle/cargo/tasks/local/CargoConfigureLocal.html">CargoConfigureLocal</a></td>
+        <td>Configures the local container.</td>
+    </tr>
 </table>
 
 ## Project layout

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ def compatibilityVersion = 1.6
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion
 group = 'com.bmuschko'
-version = '2.2.2'
+version = '2.2.3'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ def compatibilityVersion = 1.6
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion
 group = 'com.bmuschko'
-version = '2.2.3'
+version = '2.2.2'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/com/bmuschko/gradle/cargo/CargoPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/CargoPlugin.groovy
@@ -99,6 +99,7 @@ class CargoPlugin implements Plugin<Project> {
         project.task('cargoStartLocal', type: CargoStartLocal)
         project.task('cargoStopLocal', type: CargoStopLocal)
         project.task('cargoRedeployLocal', type: CargoRedeployLocal)
+        project.task('cargoConfigureLocal', type: CargoConfigureLocal)
     }
 
     private void checkValidContainerId(Project project, CargoPluginExtension cargoPluginExtension) {

--- a/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/CargoConfigureLocal.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/CargoConfigureLocal.groovy
@@ -3,6 +3,6 @@ package com.bmuschko.gradle.cargo.tasks.local
 class CargoConfigureLocal extends LocalCargoContainerTask {
 	CargoConfigureLocal() {
 		action = 'configure'
-		description = 'Configures the container'
+		description = 'Configures the local container.'
 	}
 }

--- a/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/CargoConfigureLocal.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/tasks/local/CargoConfigureLocal.groovy
@@ -1,0 +1,8 @@
+package com.bmuschko.gradle.cargo.tasks.local
+
+class CargoConfigureLocal extends LocalCargoContainerTask {
+	CargoConfigureLocal() {
+		action = 'configure'
+		description = 'Configures the container'
+	}
+}


### PR DESCRIPTION
Added a task to run the 'configure' task in cargo with a cargoConfigureLocal task.

I'd like the ability to bundle the containers configuration manually onto target via SSH (rather than having to specify usernames and passwords to remotes), so a 'configure' only task is a useful option.

This is also useful as I can add additional generated configuration directories (rather than using configFiles) into the container configuration before starting the container.

Also, I can now manually run and background the start of (e.g.) tomcat on the target using ssh rather than the blocking cargoRunLocal task.

There don't seem to be any tests around creating the cargo*Local tasks, but the implementation is trivial, so I haven't added any either.
