### PR TITLE
Proposed fix for issue #192

### DIFF
--- a/src/integrationTest/groovy/com/bmuschko/gradle/cargo/util/DeployableIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/com/bmuschko/gradle/cargo/util/DeployableIntegrationSpec.groovy
@@ -76,4 +76,21 @@ class DeployableIntegrationSpec extends AbstractIntegrationSpec {
         requestServletResponseText() == HelloWorldServletWarFixture.RESPONSE_TEXT
     }
 
+    def "can deploy without context parameter"() {
+        given:
+        buildScript << """
+            cargo {
+                deployable {
+                    file = configurations.war
+                }
+            }
+        """
+
+        when:
+        runBuild "cargoStartLocal"
+
+        then:
+        requestServletResponseText() == HelloWorldServletWarFixture.RESPONSE_TEXT
+    }
+
 }

--- a/src/main/groovy/com/bmuschko/gradle/cargo/convention/Deployable.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/convention/Deployable.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 
 /**
  * Defines Deployable convention.
@@ -30,6 +31,7 @@ class Deployable implements Serializable {
     FileCollection files
 
     @Input
+	@Optional
     String context
 
     @Internal

--- a/src/main/groovy/com/bmuschko/gradle/cargo/convention/Deployable.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/convention/Deployable.groovy
@@ -31,7 +31,7 @@ class Deployable implements Serializable {
     FileCollection files
 
     @Input
-	@Optional
+    @Optional
     String context
 
     @Internal


### PR DESCRIPTION
I don't know if there is a reason for the "context" property being mandatory but my builds are working fine without it.

Since it prevents the deployment of artifacts other than war files I think it's better to make it optional.