### PR TITLE
Add cargo-licensed-dtds to the dependencies and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ The `com.bmuschko.cargo-base` plugin already sets up the dependencies for Cargo.
 version of the libraries. Alternatively, you can define a custom version of the Cargo libraries. To do so, please use
 the `cargo` configuration name in your `dependencies` closure. Remote deployment functionality will only work with a Cargo
 version >= 1.1.0 due to a bug in the library. Please see [CARGO-962](https://codehaus-cargo.atlassian.net/browse/CARGO-962) for more information.
-The following example demonstrates how to use the version 1.4.5 of the Cargo libraries:
+The following example demonstrates how to use the version 1.7.9 of the Cargo libraries:
 
     dependencies {
-        def cargoVersion = '1.4.5'
+        def cargoVersion = '1.7.9'
         cargo "org.codehaus.cargo:cargo-core-uberjar:$cargoVersion",
+              "org.codehaus.cargo:cargo-licensed-dtds:$cargoVersion",
               "org.codehaus.cargo:cargo-ant:$cargoVersion"
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/cargo/CargoBasePlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/CargoBasePlugin.groovy
@@ -56,6 +56,7 @@ class CargoBasePlugin implements Plugin<Project> {
                 if(config.dependencies.empty) {
                     project.dependencies {
                         cargo "org.codehaus.cargo:cargo-core-uberjar:$CARGO_DEFAULT_VERSION",
+                              "org.codehaus.cargo:cargo-licensed-dtds:$CARGO_DEFAULT_VERSION",
                               "org.codehaus.cargo:cargo-ant:$CARGO_DEFAULT_VERSION"
                     }
                 }


### PR DESCRIPTION
Add `cargo-licensed-dtds` to the dependencies and documentation, which allows the `gradle-cargo-plugin` to be run offline as well as in environments where general Internet access is blocked