### PR TITLE
Version upgrades for Codehaus Cargo and Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ The `com.bmuschko.cargo-base` plugin already sets up the dependencies for Cargo.
 version of the libraries. Alternatively, you can define a custom version of the Cargo libraries. To do so, please use
 the `cargo` configuration name in your `dependencies` closure. Remote deployment functionality will only work with a Cargo
 version >= 1.1.0 due to a bug in the library. Please see [CARGO-962](https://codehaus-cargo.atlassian.net/browse/CARGO-962) for more information.
-The following example demonstrates how to use the version 1.7.10 of the Cargo libraries:
+The following example demonstrates how to use the version 1.8.3 of the Cargo libraries:
 
     dependencies {
-        def cargoVersion = '1.7.10'
+        def cargoVersion = '1.8.3'
         cargo "org.codehaus.cargo:cargo-core-uberjar:$cargoVersion",
               "org.codehaus.cargo:cargo-licensed-dtds:$cargoVersion",
               "org.codehaus.cargo:cargo-ant:$cargoVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ configurations {
 
 dependencies {
     compile localGroovy()
-    def cargoVersion = '1.7.10'
+    def cargoVersion = '1.8.3'
     compile "org.codehaus.cargo:cargo-daemon-client:$cargoVersion"
     testCompile('org.spockframework:spock-core:1.3-groovy-2.4') {
         exclude group: 'org.codehaus.groovy'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "org.ajoberstar.git-publish" version "2.0.0"
 }
 
-def compatibilityVersion = 1.6
+def compatibilityVersion = 1.8
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion
 group = 'com.bmuschko'

--- a/src/main/groovy/com/bmuschko/gradle/cargo/CargoBasePlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/cargo/CargoBasePlugin.groovy
@@ -31,7 +31,7 @@ import org.gradle.api.Task
 class CargoBasePlugin implements Plugin<Project> {
     static final String CONFIGURATION_NAME = 'cargo'
     static final String DAEMON_CONFIGURATION_NAME = 'cargoDaemon'
-    static final String CARGO_DEFAULT_VERSION = '1.7.10'
+    static final String CARGO_DEFAULT_VERSION = '1.8.3'
 
     @Override
     void apply(Project project) {


### PR DESCRIPTION
- Upgrade to Codehaus Cargo 1.8.3 
- Travis uses Java 8, so set the source and target compatibility version to Java 8